### PR TITLE
Add --include-exec-depends to catkin_topological_order

### DIFF
--- a/bin/catkin_topological_order
+++ b/bin/catkin_topological_order
@@ -21,6 +21,7 @@ def main():
     parser.add_argument('--underlay-workspaces', nargs='*', default=[], help='The paths to underlay workspaces which are only used to resolve dependencies')
     parser.add_argument('--only-folders', action='store_true', help='Only output the project folders')
     parser.add_argument('--only-names', action='store_true', help='Only output the project names')
+    parser.add_argument('--include-exec-depends', action='store_true', default=False, help='Include runtime dependencies')
     args = parser.parse_args()
 
     # verify reasonable argument combination
@@ -32,7 +33,10 @@ def main():
     if not os.path.isdir(workspace):
         sys.exit('Workspace "%s" does not exist' % workspace)
 
-    ordered_projects = topological_order(workspace, underlay_workspaces=args.underlay_workspaces)
+    ordered_projects = topological_order(
+        workspace,
+        underlay_workspaces=args.underlay_workspaces,
+        include_exec_depends=args.include_exec_depends)
     if not ordered_projects:
         sys.stderr.write('Workspace "%s" seems to not contain any projects.'
                          ' Have you passed the correct path to a '


### PR DESCRIPTION
This allows runtime dependencies to be including when determining the
topological order.